### PR TITLE
Update the TBD_1 to be a requested value of 3

### DIFF
--- a/draft-bryce-cose-merkle-mountain-range-proofs.md
+++ b/draft-bryce-cose-merkle-mountain-range-proofs.md
@@ -19,6 +19,7 @@ author:
 
 normative:
   RFC9053: COSE
+  I-D.IETF-cose-merkle-tree-proofs: COMTRE
 
 informative:
 
@@ -60,9 +61,17 @@ The storage of a tree maintained in this way is addressed as a linear array, and
 In this specification, all numbers are unsigned 64 bit integers.
 The maximum height of a single tree is 64 (which will have `g=63` for its peak).
 
-# Verifiable Data Structure
+# Description of the MMR Ledger Verifiable Data Structure
 
-The integer identifier for this Verifiable Data Structure is 2.
+This documents extends the verifiable data structure registry of {{-COMTRE}} with the following value:
+
+| Name | Value | Description | Reference
+|---
+|MMRivr_LEDGER_SHA256 | TBD_1 (requested assignment 3) | Merkle Mountain Range Ledgers, such as the MMRivr ledger | This document
+{: #verifiable-data-structure-values align="left" title="Verifiable Data Structure Algorithms"}
+
+This document defines inclusion proofs for Merkle Mountain Range (MMRivr) ledgers.
+Verifiers MUST reject all other proof types
 
 # Inclusion Proof
 


### PR DESCRIPTION
Per conversation in the IETF Architecture editor's meeting. 
CCF will request a codepoint of 2, and MMRivr will request 3 (simply alphabetical)

@robinbryce, I wasn't sure if you wanted to use MMRivr or some other short-name reference to compare to the CCF Ledger. 

cc @jag-uk

